### PR TITLE
use https instead of ssh

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -45,16 +45,16 @@
 	url = http://github.com/chrisdone/hindent.git
 [submodule "packages/multiple-cursors"]
 	path = packages/multiple-cursors
-	url = git@github.com:magnars/multiple-cursors.el.git
+	url = https://github.com/magnars/multiple-cursors.el.git
 [submodule "packages/ace-jump-mode"]
 	path = packages/ace-jump-mode
-	url = git@github.com:chrisdone/ace-jump-mode.git
+	url = https://github.com/chrisdone/ace-jump-mode.git
 [submodule "packages/flycheck"]
 	path = packages/flycheck
-	url = git@github.com:flycheck/flycheck.git
+	url = https://github.com/flycheck/flycheck.git
 [submodule "packages/number"]
 	path = packages/number
-	url = git@github.com:chrisdone/number.git
+	url = https://github.com/chrisdone/number.git
 [submodule "packages/git-modes"]
 	path = packages/git-modes
-	url = git@github.com:magit/git-modes.git
+	url = https://github.com/magit/git-modes.git


### PR DESCRIPTION
I cannot do a `git submodule update` if `.gitmodules` uses ssh as repository URLs. Changing this to `https` works okay for future users that fork your repository, and shouldn't make any significant differences for you.

This idea wasn't originally mine, though; it was borrowed from [this](https://github.com/alexbiehl/chrisdone-emacs/commit/610659ad8dbd4b81e8ef156fe5b6b6257bdbfa82) commit.