### PR TITLE
add cabal update to setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To use
     $ git submodule init
     $ git submodule update
     $ cd packages/haskell-mode; make
-    $ cd packages/structured-haskell-mode; cabal install; cd elisp; make
+    $ cd packages/structured-haskell-mode; cabal update; cabal install; cd elisp; make
     $ cabal install hasktags haskell-docs
     $ cabal install present
 


### PR DESCRIPTION
If running `cabal` for the first time, `cabal install` won't work. The user should run `cabal update` first.